### PR TITLE
Replace prints with logger

### DIFF
--- a/src/sgpo_editor/core/database_accessor.py
+++ b/src/sgpo_editor/core/database_accessor.py
@@ -181,9 +181,9 @@ class DatabaseAccessor:
             )
             columns = [desc[0] for desc in cur.description]
             rows = cur.fetchall()
-            print(f"[DEBUG] 取得時の件数: {len(rows)}")
+            logger.debug("取得時の件数: %d", len(rows))
             for row in rows:
-                print(f"columns: {columns}, row: {row}, type(row): {type(row)}")
+                logger.debug("columns: %s, row: %s, type(row): %s", columns, row, type(row))
                 row_dict = dict(zip(columns, row))
                 key = row_dict["key"]
                 entries[key] = {
@@ -195,7 +195,7 @@ class DatabaseAccessor:
                     "position": 0,  # デフォルト値を設定
                 }
 
-        print(f"entries(keys): {list(entries.keys())}, entries: {entries}")
+        logger.debug("entries(keys): %s, entries: %s", list(entries.keys()), entries)
         return entries
 
     def get_entry_basic_info(self, key: str) -> Optional[EntryDict]:

--- a/src/sgpo_editor/core/po_components/filter.py
+++ b/src/sgpo_editor/core/po_components/filter.py
@@ -167,8 +167,16 @@ class FilterComponent:
         update_filter: bool = True,
         search_text: str = "",
     ) -> List[EntryModel]:
-        print(
-            f"[DEBUG] get_filtered_entries: called with filter_text={filter_text}, filter_keyword={filter_keyword}, match_mode={match_mode}, case_sensitive={case_sensitive}, filter_status={filter_status}, filter_obsolete={filter_obsolete}, update_filter={update_filter}, search_text={search_text}"
+        logger.debug(
+            "get_filtered_entries called with filter_text=%s, filter_keyword=%s, match_mode=%s, case_sensitive=%s, filter_status=%s, filter_obsolete=%s, update_filter=%s, search_text=%s",
+            filter_text,
+            filter_keyword,
+            match_mode,
+            case_sensitive,
+            filter_status,
+            filter_obsolete,
+            update_filter,
+            search_text,
         )
         # None と空文字列は意味が異なるため区別して扱う
         #   filter_keyword が None   : キーワードフィルタをリセットしたい意図
@@ -231,8 +239,9 @@ class FilterComponent:
             and self.filtered_entries
             and len(self.filtered_entries) > 0
         ):
-            print(
-                f"[DEBUG] get_filtered_entries: self.filtered_entriesヒット {len(self.filtered_entries)}件"
+            logger.debug(
+                "get_filtered_entries: self.filtered_entriesヒット %d件",
+                len(self.filtered_entries),
             )
             # 既に計算済みのフィルタ結果がある場合はそれを使用
             return self.filtered_entries
@@ -241,8 +250,9 @@ class FilterComponent:
             # キャッシュ上の計算済みフィルタ結果をチェック
             cached_entries = self.cache_manager.get_filter_cache()
             if cached_entries is not None and len(cached_entries) > 0:
-                print(
-                    f"[DEBUG] get_filtered_entries: cache_managerヒット {len(cached_entries)}件"
+                logger.debug(
+                    "get_filtered_entries: cache_managerヒット %d件",
+                    len(cached_entries),
                 )
                 # キャッシュヒット
                 logger.debug(
@@ -297,8 +307,9 @@ class FilterComponent:
             # self.cache_manager.clear_filter_cache()
 
         self.filtered_entries = db_filtered
-        print(
-            f"[DEBUG] get_filtered_entries: DBフィルタ結果 {len(self.filtered_entries)}件返却"
+        logger.debug(
+            "get_filtered_entries: DBフィルタ結果 %d件返却",
+            len(self.filtered_entries),
         )
         return self.filtered_entries
 
@@ -353,12 +364,19 @@ class FilterComponent:
             limit=None,
             offset=0,
         )
-        print(
-            f"[DEBUG] get_filtered_entries_from_db: translation_status={translation_status}"
+        logger.debug(
+            "get_filtered_entries_from_db: translation_status=%s",
+            translation_status,
         )
-        print(f"[DEBUG] get_filtered_entries_from_db: entries件数={len(entries)}")
-        print(
-            f"[DEBUG] get_filtered_entries_from_db: entries(keys)={[e.get('key') for e in entries] if entries and isinstance(entries[0], dict) else entries}"
+        logger.debug(
+            "get_filtered_entries_from_db: entries件数=%d",
+            len(entries),
+        )
+        logger.debug(
+            "get_filtered_entries_from_db: entries(keys)=%s",
+            [e.get('key') for e in entries]
+            if entries and isinstance(entries[0], dict)
+            else entries,
         )
         return [
             EntryModel.from_dict(e) if not isinstance(e, EntryModel) else e


### PR DESCRIPTION
## Summary
- clean up debug prints in InMemoryEntryStore
- replace prints with `logger.debug` in DatabaseAccessor
- use `logger.debug` instead of print in filter component

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*