### PR TITLE
Replace prints with logger

### DIFF
--- a/src/sgpo_editor/core/database_accessor.py
+++ b/src/sgpo_editor/core/database_accessor.py
@@ -172,18 +172,11 @@ class DatabaseAccessor:
                 FROM entries
                 """
             )
-            # 件数デバッグ出力
-            cur.execute(
-                """
-                SELECT key, msgid, msgstr, fuzzy, obsolete
-                FROM entries
-                """
-            )
             columns = [desc[0] for desc in cur.description]
             rows = cur.fetchall()
-            print(f"[DEBUG] 取得時の件数: {len(rows)}")
+            logger.debug("取得時の件数: %d", len(rows))
             for row in rows:
-                print(f"columns: {columns}, row: {row}, type(row): {type(row)}")
+                logger.debug("columns: %s, row: %s, type(row): %s", columns, row, type(row))
                 row_dict = dict(zip(columns, row))
                 key = row_dict["key"]
                 entries[key] = {
@@ -195,7 +188,7 @@ class DatabaseAccessor:
                     "position": 0,  # デフォルト値を設定
                 }
 
-        print(f"entries(keys): {list(entries.keys())}, entries: {entries}")
+        logger.debug("entries(keys): %s, entries: %s", list(entries.keys()), entries)
         return entries
 
     def get_entry_basic_info(self, key: str) -> Optional[EntryDict]:

--- a/src/sgpo_editor/core/po_components/filter.py
+++ b/src/sgpo_editor/core/po_components/filter.py
@@ -167,8 +167,16 @@ class FilterComponent:
         update_filter: bool = True,
         search_text: str = "",
     ) -> List[EntryModel]:
-        print(
-            f"[DEBUG] get_filtered_entries: called with filter_text={filter_text}, filter_keyword={filter_keyword}, match_mode={match_mode}, case_sensitive={case_sensitive}, filter_status={filter_status}, filter_obsolete={filter_obsolete}, update_filter={update_filter}, search_text={search_text}"
+        logger.debug(
+            "get_filtered_entries called with filter_text=%s, filter_keyword=%s, match_mode=%s, case_sensitive=%s, filter_status=%s, filter_obsolete=%s, update_filter=%s, search_text=%s",
+            filter_text,
+            filter_keyword,
+            match_mode,
+            case_sensitive,
+            filter_status,
+            filter_obsolete,
+            update_filter,
+            search_text,
         )
         # None と空文字列は意味が異なるため区別して扱う
         #   filter_keyword が None   : キーワードフィルタをリセットしたい意図
@@ -231,8 +239,9 @@ class FilterComponent:
             and self.filtered_entries
             and len(self.filtered_entries) > 0
         ):
-            print(
-                f"[DEBUG] get_filtered_entries: self.filtered_entriesヒット {len(self.filtered_entries)}件"
+            logger.debug(
+                "get_filtered_entries: self.filtered_entriesヒット %d件",
+                len(self.filtered_entries),
             )
             # 既に計算済みのフィルタ結果がある場合はそれを使用
             return self.filtered_entries
@@ -241,8 +250,9 @@ class FilterComponent:
             # キャッシュ上の計算済みフィルタ結果をチェック
             cached_entries = self.cache_manager.get_filter_cache()
             if cached_entries is not None and len(cached_entries) > 0:
-                print(
-                    f"[DEBUG] get_filtered_entries: cache_managerヒット {len(cached_entries)}件"
+                logger.debug(
+                    "get_filtered_entries: cache_managerヒット %d件",
+                    len(cached_entries),
                 )
                 # キャッシュヒット
                 logger.debug(
@@ -297,8 +307,9 @@ class FilterComponent:
             # self.cache_manager.clear_filter_cache()
 
         self.filtered_entries = db_filtered
-        print(
-            f"[DEBUG] get_filtered_entries: DBフィルタ結果 {len(self.filtered_entries)}件返却"
+        logger.debug(
+            "get_filtered_entries: DBフィルタ結果 %d件返却",
+            len(self.filtered_entries),
         )
         return self.filtered_entries
 
@@ -353,12 +364,19 @@ class FilterComponent:
             limit=None,
             offset=0,
         )
-        print(
-            f"[DEBUG] get_filtered_entries_from_db: translation_status={translation_status}"
+        logger.debug(
+            "get_filtered_entries_from_db: translation_status=%s",
+            translation_status,
         )
-        print(f"[DEBUG] get_filtered_entries_from_db: entries件数={len(entries)}")
-        print(
-            f"[DEBUG] get_filtered_entries_from_db: entries(keys)={[e.get('key') for e in entries] if entries and isinstance(entries[0], dict) else entries}"
+        logger.debug(
+            "get_filtered_entries_from_db: entries件数=%d",
+            len(entries),
+        )
+        logger.debug(
+            "get_filtered_entries_from_db: entries(keys)=%s",
+            [e.get('key') for e in entries]
+            if entries and isinstance(entries[0], dict)
+            else entries,
         )
         return [
             EntryModel.from_dict(e) if not isinstance(e, EntryModel) else e

--- a/src/sgpo_editor/models/database.py
+++ b/src/sgpo_editor/models/database.py
@@ -236,7 +236,7 @@ class InMemoryEntryStore:
             # デバッグ: insert直後の件数確認
             cur.execute("SELECT COUNT(*) FROM entries")
             count = cur.fetchone()[0]
-            print(f"[DEBUG] INSERT直後の件数: {count}")
+            logger.debug("INSERT直後の件数: %s", count)
 
             # 挿入されたエントリのIDを取得
             # keyとidのマッピングを作成
@@ -551,7 +551,9 @@ class InMemoryEntryStore:
             List[Dict[str, Any]]: エントリのリスト
         """
         # デバッグ用ログ出力
-        print(f"InMemoryEntryStore.get_entries呼び出し: search_text={search_text}")
+        logger.debug(
+            "InMemoryEntryStore.get_entries called: search_text=%s", search_text
+        )
 
         query = """
             SELECT e.*, GROUP_CONCAT(f.flag) as flags, d.position
@@ -656,21 +658,19 @@ class InMemoryEntryStore:
         # 翻訳状態によるフィルタリングは上記の条件で処理済み
 
         # キーワード検索条件（msgidとmsgstrの両方で検索）
-        import logging
-
-        logging.debug(f"InMemoryEntryStore.get_entries: search_text={search_text}")
+        logger.debug("InMemoryEntryStore.get_entries: search_text=%s", search_text)
 
         # 空のキーワードを処理
         if search_text is None:
             # Noneの場合は検索条件を追加しない
-            print("キーワードがNoneのため、検索条件を追加しません")
+            logger.debug("キーワードがNoneのため、検索条件を追加しません")
         elif isinstance(search_text, str):
             # 文字列の場合は空白除去してチェック
             search_text = search_text.strip()
             if not search_text:  # 空白文字のみの場合はスキップ
-                print("空のキーワードのため、検索条件を追加しません")
+                logger.debug("空のキーワードのため、検索条件を追加しません")
             else:
-                print(f"キーワード検索条件を追加: '{search_text}'")
+                logger.debug("キーワード検索条件を追加: '%s'", search_text)
                 # 完全一致検索に変更し、テストケースに合わせる
                 if search_text.endswith("1"):
                     # test1のようなテストケースに対応
@@ -745,50 +745,52 @@ class InMemoryEntryStore:
             query += " ORDER BY COALESCE(d.position, 0) ASC"
 
         # デバッグ用ログ出力
-        print(f"SQLクエリ: {query}")
-        print(f"SQLパラメータ: {params}")
+        logger.debug("SQLクエリ: %s", query)
+        logger.debug("SQLパラメータ: %s", params)
         if search_text:
-            print(f"キーワード検索条件: '{search_text}'")
+            logger.debug("キーワード検索条件: '%s'", search_text)
 
         # クエリ実行
         try:
             # クエリとパラメータを詳細に表示
-            logging.debug(f"SQLクエリ: {query}")
-            logging.debug(f"SQLパラメータ: {params}")
+            logger.debug("SQLクエリ: %s", query)
+            logger.debug("SQLパラメータ: %s", params)
 
             # クエリ実行
             cursor = self._conn.execute(query, params)
             entries = [
                 self._row_to_dict_from_cursor(cursor, row) for row in cursor.fetchall()
             ]
-            print(f"取得したエントリ数: {len(entries)}件")
+            logger.debug("取得したエントリ数: %d件", len(entries))
 
             # キーワード検索の場合、最初の数件を表示
             if search_text and search_text.strip():
-                print("検索結果のサンプル:")
+                logger.debug("検索結果のサンプル:")
                 for i, entry in enumerate(entries[:3]):
                     msgid = entry.get("msgid", "")[:30]
                     msgstr = entry.get("msgstr", "")[:30]
-                    print(f"  エントリ {i + 1}: msgid={msgid}... msgstr={msgstr}...")
+                    logger.debug("  エントリ %d: msgid=%s... msgstr=%s...", i + 1, msgid, msgstr)
 
                 # キーワードに一致するか確認
                 if len(entries) > 0:
-                    print(f"キーワード '{search_text}' に一致するか確認:")
+                    logger.debug("キーワード '%s' に一致するか確認:", search_text)
                     first_entry = entries[0]
                     msgid = first_entry.get("msgid", "")
                     msgstr = first_entry.get("msgstr", "")
-                    print(
-                        f"  msgid '{msgid}' に '{search_text}' が含まれるか: {
-                            search_text.lower() in msgid.lower()
-                        }"
+                    logger.debug(
+                        "  msgid '%s' に '%s' が含まれるか: %s",
+                        msgid,
+                        search_text,
+                        search_text.lower() in msgid.lower(),
                     )
-                    print(
-                        f"  msgstr '{msgstr}' に '{search_text}' が含まれるか: {
-                            search_text.lower() in msgstr.lower()
-                        }"
+                    logger.debug(
+                        "  msgstr '%s' に '%s' が含まれるか: %s",
+                        msgstr,
+                        search_text,
+                        search_text.lower() in msgstr.lower(),
                     )
         except Exception as e:
-            print(f"SQLクエリ実行エラー: {str(e)}")
+            logger.error(f"SQLクエリ実行エラー: {str(e)}")
             import traceback
 
             traceback.print_exc()
@@ -822,7 +824,7 @@ class InMemoryEntryStore:
                     [(entry_id, i) for i, entry_id in enumerate(entry_ids)],
                 )
             except Exception as e:
-                print(f"エントリの表示順序を変更中にエラーが発生しました: {str(e)}")
+                logger.error(f"エントリの表示順序を変更中にエラーが発生しました: {str(e)}")
             finally:
                 # 制約を有効化
                 cur.execute("PRAGMA foreign_keys = ON")


### PR DESCRIPTION
## Summary
- clean up debug prints in InMemoryEntryStore
- replace prints with `logger.debug` in DatabaseAccessor
- use `logger.debug` instead of print in filter component
- drop redundant query in `get_all_entries_basic_info`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*