### PR TITLE
Enable row selection highlight

### DIFF
--- a/src/sgpo_editor/gui/table_manager.py
+++ b/src/sgpo_editor/gui/table_manager.py
@@ -6,7 +6,12 @@ from typing import Callable, Dict, List, Optional, Set
 
 from PySide6.QtCore import QSettings, Qt
 from PySide6.QtGui import QColor, QBrush
-from PySide6.QtWidgets import QHeaderView, QTableWidget, QTableWidgetItem
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QHeaderView,
+    QTableWidget,
+    QTableWidgetItem,
+)
 
 from sgpo_editor.core.cache_manager import EntryCacheManager
 from sgpo_editor.core.viewer_po_file import ViewerPOFile
@@ -151,6 +156,9 @@ class TableManager:
             self.table.horizontalHeader().setSectionResizeMode(
                 i, QHeaderView.ResizeMode.Interactive
             )
+
+        # 行単位で選択されるように設定
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
 
         # 保存された列幅を読み込む、なければデフォルト値を使用
         self._load_column_widths()

--- a/tests/gui/table/test_table_manager.py
+++ b/tests/gui/table/test_table_manager.py
@@ -7,7 +7,12 @@ import json
 import sys
 from unittest.mock import MagicMock, patch
 
-from PySide6.QtWidgets import QApplication, QHeaderView, QTableWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QAbstractItemView,
+    QHeaderView,
+    QTableWidget,
+)
 
 from sgpo_editor.gui.table_manager import TableManager
 from sgpo_editor.core.cache_manager import EntryCacheManager
@@ -60,6 +65,12 @@ class TestTableManager:
                 self.table.horizontalHeader().sectionResizeMode(i)
                 == QHeaderView.ResizeMode.Interactive
             )
+
+        # 選択モードが行単位になっているか確認
+        assert (
+            self.table.selectionBehavior()
+            == QAbstractItemView.SelectionBehavior.SelectRows
+        )
 
     @patch("sgpo_editor.gui.table_manager.QSettings")
     def test_save_column_widths(self, mock_settings):


### PR DESCRIPTION
## Summary
- highlight an entire row when selecting an entry
- test the table manager row selection behaviour

## Testing
- `uv pip install --system -e .[test]` *(fails: No route to host)*
- `python -m pytest -k test_table_manager.py -q` *(fails: No module named pytest)*