### PR TITLE
Fix naming mismatch for entry cache checks

### DIFF
--- a/src/sgpo_editor/core/po_components/retriever.py
+++ b/src/sgpo_editor/core/po_components/retriever.py
@@ -131,7 +131,7 @@ class EntryRetrieverComponent:
         )
 
         # 基本情報キャッシュからエントリを取得
-        if self.cache_manager.exists_entry(key):
+        if self.cache_manager.has_entry_in_cache(key):
             basic_info = self.cache_manager.get_entry(key)
             logger.debug(
                 f"EntryRetrieverComponent.get_entry_basic_info: キャッシュヒット key={key}"
@@ -162,7 +162,7 @@ class EntryRetrieverComponent:
             return
 
         # キャッシュにないキーを特定
-        missing_keys = [key for key in keys if not self.cache_manager.exists_entry(key)]
+        missing_keys = [key for key in keys if not self.cache_manager.has_entry_in_cache(key)]
         if not missing_keys:
             return
 

--- a/src/sgpo_editor/core/viewer_po_file_entry_retriever.py
+++ b/src/sgpo_editor/core/viewer_po_file_entry_retriever.py
@@ -117,7 +117,7 @@ class ViewerPOFileEntryRetriever(ViewerPOFileBase):
         )
 
         # 基本情報キャッシュからエントリを取得
-        if self.cache_manager.exists_entry(key):
+        if self.cache_manager.has_entry_in_cache(key):
             basic_info = self.cache_manager.get_entry(key)
             logger.debug(
                 f"ViewerPOFileEntryRetriever.get_entry_basic_info: キャッシュヒット key={key}"
@@ -148,7 +148,7 @@ class ViewerPOFileEntryRetriever(ViewerPOFileBase):
             return
 
         # キャッシュにないキーを特定
-        missing_keys = [key for key in keys if not self.cache_manager.exists_entry(key)]
+        missing_keys = [key for key in keys if not self.cache_manager.has_entry_in_cache(key)]
         if not missing_keys:
             return
 

--- a/src/sgpo_editor/gui/facades/entry_list_facade.py
+++ b/src/sgpo_editor/gui/facades/entry_list_facade.py
@@ -395,7 +395,7 @@ class EntryListFacade(QObject):
 
                 key = item.data(Qt.ItemDataRole.UserRole)
                 # CacheManager を ViewerPOFile から取得して使用
-                if key and not current_po.cache_manager.exists_entry(key):
+                if key and not current_po.cache_manager.has_entry_in_cache(key):
                     # プリフェッチ中でもないことを確認
                     if not current_po.cache_manager.is_key_being_prefetched(key):
                         keys_to_prefetch.append(key)


### PR DESCRIPTION
## Summary
- replace calls to `exists_entry` with `has_entry_in_cache`

## Testing
- `pytest -q` *(fails: command not found)*