### PR TITLE
Fix multiline f-strings

### DIFF
--- a/profile_entry_selection.py
+++ b/profile_entry_selection.py
@@ -127,9 +127,7 @@ def profile_entry_selection():
         event_handler._update_detail_view(row)
         row_end_time = time.time()
         print(
-            f"ランダム選択 {i + 1} (Row {row}): {
-                (row_end_time - row_start_time) * 1000:.2f
-            } ms"
+            f"ランダム選択 {i + 1} (Row {row}): {(row_end_time - row_start_time) * 1000:.2f} ms"
         )
 
     # 時間計測終了

--- a/tests/gui/test_keyword_filter/test_database_keyword_handling.py
+++ b/tests/gui/test_keyword_filter/test_database_keyword_handling.py
@@ -48,9 +48,7 @@ class TestDatabaseKeywordHandling:
         # データベースにエントリを追加 (db_accessor経由)
         po_file.db_accessor.add_entries_bulk(normal_entries + test_entries)
         print(
-            f"\n[SETUP] データベースに追加したエントリ数: 通常={
-                len(normal_entries)
-            }件, test含む={len(test_entries)}件"
+            f"\n[SETUP] データベースに追加したエントリ数: 通常={len(normal_entries)}件, test含む={len(test_entries)}件"
         )
 
         # データがロードされたことを示すフラグを設定 (不要)

--- a/tests/gui/test_keyword_filter/test_filter_debug.py
+++ b/tests/gui/test_keyword_filter/test_filter_debug.py
@@ -94,9 +94,7 @@ class TestFilterDebug:
 
         # 4. 検証: リセット後のエントリ数が初期状態と同じになるはず
         logger.debug(
-            f"\n[DEBUG] 検証: リセット後({reset_count}) == 初期状態({
-                initial_count
-            }) -> {reset_count == initial_count}"
+            f"\n[DEBUG] 検証: リセット後({reset_count}) == 初期状態({initial_count}) -> {reset_count == initial_count}"
         )
         assert reset_count == initial_count, (
             f"フィルタリセット後のエントリ数が初期状態と異なります: {reset_count} != {initial_count}"

--- a/tests/gui/test_keyword_filter/test_filter_reset.py
+++ b/tests/gui/test_keyword_filter/test_filter_reset.py
@@ -41,9 +41,7 @@ class TestFilterReset:
 
         # 1. 初期状態の確認
         print(
-            f"\n[TEST] ViewerPOFile初期状態: search_text={
-                po_file.get_filters().get('search_text')
-            }, translation_status={po_file.get_filters().get('translation_status')}"
+            f"\n[TEST] ViewerPOFile初期状態: search_text={po_file.get_filters().get('search_text')}, translation_status={po_file.get_filters().get('translation_status')}"
         )
         initial_entries = po_file.get_filtered_entries(SearchCriteria())
         initial_count = len(initial_entries)
@@ -63,9 +61,7 @@ class TestFilterReset:
         reset_count = len(reset_entries)
         print(f"[TEST] フィルタリセット後のエントリ数: {reset_count}件")
         print(
-            f"[TEST] リセット後のViewerPOFile状態: search_text={
-                po_file.get_filters().get('search_text')
-            }, translation_status={po_file.get_filters().get('translation_status')}"
+            f"[TEST] リセット後のViewerPOFile状態: search_text={po_file.get_filters().get('search_text')}, translation_status={po_file.get_filters().get('translation_status')}"
         )
 
         # 4. 検証: リセット後のエントリ数が初期状態と同じになるはず
@@ -90,9 +86,7 @@ class TestFilterReset:
         # 1. 初期状態の確認
         initial_filters = po_file.get_filters()
         print(
-            f"\n[TEST] ViewerPOFile初期状態: search_text={
-                initial_filters.get('search_text')
-            }, translation_status={initial_filters.get('translation_status')}"
+            f"\n[TEST] ViewerPOFile初期状態: search_text={initial_filters.get('search_text')}, translation_status={initial_filters.get('translation_status')}"
         )
 
         # 2. 初期状態で全エントリを取得
@@ -104,9 +98,7 @@ class TestFilterReset:
         po_file.get_filtered_entries(SearchCriteria(update_filter=True, filter_keyword="test"))
         filtered_filters = po_file.get_filters()
         print(
-            f"[TEST] フィルタ後のViewerPOFile状態: search_text={
-                filtered_filters.get('search_text')
-            }, translation_status={filtered_filters.get('translation_status')}"
+            f"[TEST] フィルタ後のViewerPOFile状態: search_text={filtered_filters.get('search_text')}, translation_status={filtered_filters.get('translation_status')}"
         )
 
         # 4. フィルタをリセット（空文字列）
@@ -116,9 +108,7 @@ class TestFilterReset:
         reset_count = len(reset_entries)
         reset_filters = po_file.get_filters()
         print(
-            f"[TEST] リセット後のViewerPOFile状態: search_text={
-                reset_filters.get('search_text')
-            }, translation_status={reset_filters.get('translation_status')}"
+            f"[TEST] リセット後のViewerPOFile状態: search_text={reset_filters.get('search_text')}, translation_status={reset_filters.get('translation_status')}"
         )
 
         # 5. 検証: リセット後のエントリ数が初期状態と同じになるはず
@@ -128,9 +118,7 @@ class TestFilterReset:
 
         # 6. 検証: リセット後のフィルタ状態が初期状態と同じになるはず
         assert reset_filters.get('search_text') == initial_filters.get('search_text'), (
-            f"フィルタリセット後のsearch_textが初期状態と異なります: {
-                reset_filters.get('search_text')
-            } != {initial_filters.get('search_text')}"
+            f"フィルタリセット後のsearch_textが初期状態と異なります: {reset_filters.get('search_text')} != {initial_filters.get('search_text')}"
         )
 
         # 7. 検証: データベースの状態を直接確認
@@ -152,9 +140,7 @@ class TestFilterReset:
 
         # 1. 初期状態の確認
         print(
-            f"\n[TEST] ViewerPOFile初期状態: search_text={
-                po_file.get_filters().get('search_text')
-            }, translation_status={po_file.get_filters().get('translation_status')}"
+            f"\n[TEST] ViewerPOFile初期状態: search_text={po_file.get_filters().get('search_text')}, translation_status={po_file.get_filters().get('translation_status')}"
         )
 
         # 2. 初期状態で全エントリを取得
@@ -190,9 +176,7 @@ class TestFilterReset:
 
         # 1. 初期状態の確認
         print(
-            f"\n[TEST] ViewerPOFile初期状態: search_text={
-                po_file.get_filters().get('search_text')
-            }, translation_status={po_file.get_filters().get('translation_status')}"
+            f"\n[TEST] ViewerPOFile初期状態: search_text={po_file.get_filters().get('search_text')}, translation_status={po_file.get_filters().get('translation_status')}"
         )
 
         # 2. 初期状態で全エントリを取得
@@ -211,9 +195,7 @@ class TestFilterReset:
         # フィルタ後の状態を確認
         filtered_state = po_file.get_filters()
         print(
-            f"[TEST] フィルタ後のViewerPOFile状態: search_text={
-                filtered_state.get('search_text')
-            }, translation_status={filtered_state.get('translation_status')}"
+            f"[TEST] フィルタ後のViewerPOFile状態: search_text={filtered_state.get('search_text')}, translation_status={filtered_state.get('translation_status')}"
         )
 
         # SearchCriteria対応後はフィルタ状態の検証を省略
@@ -231,9 +213,7 @@ class TestFilterReset:
         # リセット後の状態を確認
         reset_state = po_file.get_filters()
         print(
-            f"[TEST] リセット後のViewerPOFile状態: search_text={
-                reset_state.get('search_text')
-            }, translation_status={reset_state.get('translation_status')}"
+            f"[TEST] リセット後のViewerPOFile状態: search_text={reset_state.get('search_text')}, translation_status={reset_state.get('translation_status')}"
         )
 
         # 5. 検証: リセット後のエントリ数が初期状態と同じになるはず

--- a/tests/gui/test_keyword_filter/test_filter_reset_basic.py
+++ b/tests/gui/test_keyword_filter/test_filter_reset_basic.py
@@ -186,9 +186,7 @@ class TestFilterResetBasic:
         # 1. 初期状態の確認
         initial_filters = po_file.get_filters()
         print(
-            f"\n[TEST] ViewerPOFile初期状態: search_text={
-                initial_filters.get('search_text')
-            }, translation_status={initial_filters.get('translation_status')}"
+            f"\n[TEST] ViewerPOFile初期状態: search_text={initial_filters.get('search_text')}, translation_status={initial_filters.get('translation_status')}"
         )
         # print(
         #     f"[TEST] 内部キャッシュ: _entry_obj_cache件数={
@@ -208,9 +206,7 @@ class TestFilterResetBasic:
         po_file.get_filtered_entries(SearchCriteria(filter_keyword="test", update_filter=True))
         filtered_filters = po_file.get_filters()
         print(
-            f"[TEST] フィルタ適用後のViewerPOFile状態: search_text={
-                filtered_filters.get('search_text')
-            }, translation_status={filtered_filters.get('translation_status')}"
+            f"[TEST] フィルタ適用後のViewerPOFile状態: search_text={filtered_filters.get('search_text')}, translation_status={filtered_filters.get('translation_status')}"
         )
         # print(
         #     f"[TEST] フィルタ適用後の内部キャッシュ: _entry_obj_cache件数={
@@ -226,9 +222,7 @@ class TestFilterResetBasic:
         reset_filters = po_file.get_filters()
         print(f"[TEST] リセット後のエントリ数: {reset_count}件")
         print(
-            f"[TEST] リセット後のViewerPOFile状態: search_text={
-                reset_filters.get('search_text')
-            }, translation_status={reset_filters.get('translation_status')}"
+            f"[TEST] リセット後のViewerPOFile状態: search_text={reset_filters.get('search_text')}, translation_status={reset_filters.get('translation_status')}"
         )
         # print(
         #     f"[TEST] リセット後の内部キャッシュ: _entry_obj_cache件数={

--- a/tests/gui/test_keyword_filter/test_keyword_filter.py
+++ b/tests/gui/test_keyword_filter/test_keyword_filter.py
@@ -134,14 +134,10 @@ class TestKeywordFilter:
 
         # タイマーの接続を確認
         print(
-            f"[TEST] _filter_timerが存在するか: {
-                hasattr(search_widget, '_filter_timer')
-            }"
+            f"[TEST] _filter_timerが存在するか: {hasattr(search_widget, '_filter_timer')}"
         )
         print(
-            f"[TEST] _search_timerが存在するか: {
-                hasattr(search_widget, '_search_timer')
-            }"
+            f"[TEST] _search_timerが存在するか: {hasattr(search_widget, '_search_timer')}"
         )
 
         # コールバックを置き換え
@@ -392,9 +388,7 @@ class TestKeywordFilter:
                 assert keyword_found, "キーワードを含むエントリが見つかりません"
 
                 print(
-                    f"[TEST] フィルタリングテスト成功: {
-                        len(keyword_entries)
-                    }件のエントリが見つかりました"
+                    f"[TEST] フィルタリングテスト成功: {len(keyword_entries)}件のエントリが見つかりました"
                 )
         except Exception as e:
             print(


### PR DESCRIPTION
## Summary
- close f-strings that were split across lines

## Testing
- `uv run ruff check --fix` *(fails: F821 Undefined name `cast`, etc.)*
- `uv run ty check src --exit-zero`
- `uv run pytest -q` *(fails: Could not load the Qt platform plugin "xcb")*