### PR TITLE
Fix TypeAlias imports and annotate init methods

### DIFF
--- a/src/sgpo_editor/models/entry.py
+++ b/src/sgpo_editor/models/entry.py
@@ -94,7 +94,7 @@ class EntryModel(BaseModel):
         Field(default_factory=dict)
     )  # 任意のメタデータを格納する辞書
 
-    def __init__(self, **data):
+    def __init__(self, **data: Any) -> None:
         logger.debug("EntryModel.__init__ called, data=%s", data)
         # evaluation_stateが渡された場合、初期化後に設定
         evaluation_state = data.pop("evaluation_state", EvaluationState.NOT_EVALUATED)

--- a/src/sgpo_editor/models/stats.py
+++ b/src/sgpo_editor/models/stats.py
@@ -51,7 +51,7 @@ class StatsModel(BaseModel):
             return ""
         return str(v)
 
-    def __init__(self, **data: Any):
+    def __init__(self, **data: Any) -> None:
         super().__init__(**data)
         self.update_progress()
 

--- a/src/sgpo_editor/types.py
+++ b/src/sgpo_editor/types.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Dict,
     List,
-    TypeAlias,
     Union,
     Tuple,
     Callable,
@@ -17,6 +16,7 @@ from typing import (
     TypedDict,
     TYPE_CHECKING,
 )
+from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from sgpo_editor.models.entry import EntryModel

--- a/src/sgpo_editor/utils/llm_utils.py
+++ b/src/sgpo_editor/utils/llm_utils.py
@@ -6,7 +6,8 @@
 import json
 import logging
 from enum import Enum, auto
-from typing import Dict, List, Optional, TypedDict, cast, TypeAlias
+from typing import Dict, List, Optional, TypedDict, cast
+from typing_extensions import TypeAlias
 
 import anthropic
 import openai


### PR DESCRIPTION
## Summary
- import `TypeAlias` from `typing_extensions`
- annotate init methods with `-> None`

## Testing
- `uv run ruff check --fix`
- `uv run ty check src --exit-zero`
- `uv run pytest -q` *(fails: Could not load the Qt platform plugin "xcb")*