### PR TITLE
Normalize flags and adjust fuzzy

### DIFF
--- a/src/sgpo_editor/models/entry.py
+++ b/src/sgpo_editor/models/entry.py
@@ -125,8 +125,8 @@ class EntryModel(BaseModel):
     @property
     def fuzzy(self) -> bool:
         """ファジーかどうか"""
-        normalized = [str(flag).lower() for flag in self.flags]
-        return "fuzzy" in normalized
+        normalized_flags = [str(flag).lower() for flag in self.flags]
+        return "fuzzy" in normalized_flags
 
     @fuzzy.setter
     def fuzzy(self, value: bool) -> None:
@@ -407,7 +407,7 @@ class EntryModel(BaseModel):
 
     @field_validator("flags")
     @classmethod
-    def normalize_flags(cls, v: List[str]) -> List[str]:
+    def lowercase_flags(cls, v: List[str]) -> List[str]:
         """flagsを小文字に正規化"""
         return [flag.lower() for flag in v]
 


### PR DESCRIPTION
## Summary
- ensure flags are stored in lowercase
- check normalized list for fuzzy state

## Testing
- `uv run ruff check --fix src/sgpo_editor/models/entry.py tests/models/entry/test_entry_model.py`
- `uv run ty check src --exit-zero`
- `QT_QPA_PLATFORM=offscreen uv run pytest tests/models/entry/test_entry_model.py -q`