### PR TITLE
Add count_entries type checks

### DIFF
--- a/src/sgpo_editor/core/po_components/stats.py
+++ b/src/sgpo_editor/core/po_components/stats.py
@@ -76,20 +76,50 @@ class StatsComponent:
 
         # 総エントリ数
         total = self.db_accessor.count_entries()
+        if not isinstance(total, int):
+            logger.warning("count_entries returned non-int value: %r", total)
+        assert isinstance(total, int), "count_entries must return int"
+
         # 翻訳済みエントリ数 (msgstrが空でないもの)
         translated = self.db_accessor.count_entries_with_condition(
             {"field": "msgstr", "value": "", "operator": "!="}
         )
+        if not isinstance(translated, int):
+            logger.warning(
+                "count_entries_with_condition for translated returned non-int value: %r",
+                translated,
+            )
+        assert isinstance(translated, int), "count_entries_with_condition must return int"
+
         # 未翻訳エントリ数 (msgstrが空のもの)
         untranslated = self.db_accessor.count_entries_with_condition(
             {"field": "msgstr", "value": "", "operator": "="}
         )
+        if not isinstance(untranslated, int):
+            logger.warning(
+                "count_entries_with_condition for untranslated returned non-int value: %r",
+                untranslated,
+            )
+        assert isinstance(untranslated, int), "count_entries_with_condition must return int"
+
         # fuzzyフラグ付きエントリ数
         fuzzy = self.db_accessor.count_entries_with_flag("fuzzy")
+        if not isinstance(fuzzy, int):
+            logger.warning(
+                "count_entries_with_flag returned non-int value: %r", fuzzy
+            )
+        assert isinstance(fuzzy, int), "count_entries_with_flag must return int"
+
         # obsoleteフラグ付きエントリ数
         obsolete = self.db_accessor.count_entries_with_condition(
             {"field": "obsolete", "value": True, "operator": "="}
         )
+        if not isinstance(obsolete, int):
+            logger.warning(
+                "count_entries_with_condition for obsolete returned non-int value: %r",
+                obsolete,
+            )
+        assert isinstance(obsolete, int), "count_entries_with_condition must return int"
 
         # 翻訳率の計算 (0除算対策)
         percent_translated = (translated / total * 100) if total > 0 else 0.0
@@ -114,7 +144,13 @@ class StatsComponent:
         """
         if not self.db_accessor:
             return 0
-        return self.db_accessor.count_entries_with_flag(flag)
+        result = self.db_accessor.count_entries_with_flag(flag)
+        if not isinstance(result, int):
+            logger.warning(
+                "count_entries_with_flag returned non-int value: %r", result
+            )
+        assert isinstance(result, int), "count_entries_with_flag must return int"
+        return result
 
     def get_flag_statistics(self) -> Dict[str, int]:
         """すべてのフラグの統計情報を取得する
@@ -130,6 +166,11 @@ class StatsComponent:
 
         for flag in all_flags:
             count = self.db_accessor.count_entries_with_flag(flag)
+            if not isinstance(count, int):
+                logger.warning(
+                    "count_entries_with_flag returned non-int value: %r", count
+                )
+            assert isinstance(count, int), "count_entries_with_flag must return int"
             result[flag] = count
 
         return result
@@ -205,16 +246,34 @@ class StatsComponent:
         singular = self.db_accessor.count_entries_with_condition(
             {"field": "msgid_plural", "value": None, "operator": "="}
         )
+        if not isinstance(singular, int):
+            logger.warning(
+                "count_entries_with_condition for singular returned non-int value: %r",
+                singular,
+            )
+        assert isinstance(singular, int), "count_entries_with_condition must return int"
 
         # 複数形エントリ（msgid_pluralがあるもの）
         plural = self.db_accessor.count_entries_with_condition(
             {"field": "msgid_plural", "value": None, "operator": "!="}
         )
+        if not isinstance(plural, int):
+            logger.warning(
+                "count_entries_with_condition for plural returned non-int value: %r",
+                plural,
+            )
+        assert isinstance(plural, int), "count_entries_with_condition must return int"
 
         # コンテキスト付きエントリ（msgctxtがあるもの）
         with_context = self.db_accessor.count_entries_with_condition(
             {"field": "msgctxt", "value": None, "operator": "!="}
         )
+        if not isinstance(with_context, int):
+            logger.warning(
+                "count_entries_with_condition for with_context returned non-int value: %r",
+                with_context,
+            )
+        assert isinstance(with_context, int), "count_entries_with_condition must return int"
 
         return {
             "singular": singular,

--- a/tests/integration/test_viewer_po_file_stats.py
+++ b/tests/integration/test_viewer_po_file_stats.py
@@ -15,9 +15,9 @@ class TestViewerPOFileStats(unittest.TestCase):
         # db_accessor のモックをコンストラクタに渡す
         self.mock_db_accessor = MagicMock()
         # StatsComponent.get_statisticsメソッドで使用されるメソッドの戻り値を設定
-        self.mock_db_accessor.count_entries.return_value = 0
-        self.mock_db_accessor.count_entries_with_condition.return_value = 0
-        self.mock_db_accessor.count_entries_with_flag.return_value = 0
+        self.mock_db_accessor.count_entries.return_value = int(0)
+        self.mock_db_accessor.count_entries_with_condition.return_value = int(0)
+        self.mock_db_accessor.count_entries_with_flag.return_value = int(0)
         self.viewer = ViewerPOFileRefactored(db_accessor=self.mock_db_accessor)
 
     def test_get_stats_has_progress_attribute(self):
@@ -33,9 +33,9 @@ class TestViewerPOFileStats(unittest.TestCase):
         ]
 
         # StatsComponent.get_statisticsメソッドで使用されるメソッドの戻り値を設定
-        self.mock_db_accessor.count_entries.return_value = 3
-        self.mock_db_accessor.count_entries_with_condition.return_value = 1
-        self.mock_db_accessor.count_entries_with_flag.return_value = 1
+        self.mock_db_accessor.count_entries.return_value = int(3)
+        self.mock_db_accessor.count_entries_with_condition.return_value = int(1)
+        self.mock_db_accessor.count_entries_with_flag.return_value = int(1)
 
         # get_filtered_entriesをモック化
         self.viewer.get_filtered_entries = MagicMock(return_value=mock_entries)
@@ -62,9 +62,9 @@ class TestViewerPOFileStats(unittest.TestCase):
             EntryModel(key="3", msgid="test3", msgstr="", fuzzy=False),
         ]
         # StatsComponent.get_statisticsメソッドで使用されるメソッドの戻り値を設定
-        self.mock_db_accessor.count_entries.return_value = 3
-        self.mock_db_accessor.count_entries_with_condition.return_value = 1
-        self.mock_db_accessor.count_entries_with_flag.return_value = 1
+        self.mock_db_accessor.count_entries.return_value = int(3)
+        self.mock_db_accessor.count_entries_with_condition.return_value = int(1)
+        self.mock_db_accessor.count_entries_with_flag.return_value = int(1)
         
         self.viewer.get_filtered_entries = MagicMock(return_value=mock_entries1)
         # get_statsメソッドの中でget_filtered_entriesが呼ばれる場合に備えて、引数をチェックする
@@ -79,9 +79,9 @@ class TestViewerPOFileStats(unittest.TestCase):
             EntryModel(key="2", msgid="test2", msgstr="テスト2", fuzzy=False),
         ]
         # StatsComponent.get_statisticsメソッドで使用されるメソッドの戻り値を設定
-        self.mock_db_accessor.count_entries.return_value = 2
-        self.mock_db_accessor.count_entries_with_condition.return_value = 2
-        self.mock_db_accessor.count_entries_with_flag.return_value = 0
+        self.mock_db_accessor.count_entries.return_value = int(2)
+        self.mock_db_accessor.count_entries_with_condition.return_value = int(2)
+        self.mock_db_accessor.count_entries_with_flag.return_value = int(0)
         
         self.viewer.get_filtered_entries = MagicMock(return_value=mock_entries2)
         # get_statsメソッドの中でget_filtered_entriesが呼ばれる場合に備えて、引数をチェックする
@@ -92,9 +92,9 @@ class TestViewerPOFileStats(unittest.TestCase):
 
         # ケース3: エントリがない場合
         # StatsComponent.get_statisticsメソッドで使用されるメソッドの戻り値を設定
-        self.mock_db_accessor.count_entries.return_value = 0
-        self.mock_db_accessor.count_entries_with_condition.return_value = 0
-        self.mock_db_accessor.count_entries_with_flag.return_value = 0
+        self.mock_db_accessor.count_entries.return_value = int(0)
+        self.mock_db_accessor.count_entries_with_condition.return_value = int(0)
+        self.mock_db_accessor.count_entries_with_flag.return_value = int(0)
         
         self.viewer.get_filtered_entries = MagicMock(return_value=[])
         # get_statsメソッドの中でget_filtered_entriesが呼ばれる場合に備えて、引数をチェックする


### PR DESCRIPTION
## Summary
- warn/assert when database count methods return non-int values
- ensure tests use int return values for mocks

## Testing
- `uv run ruff check --fix`
- `uv run ty check src --exit-zero`
- `uv run pytest` *(fails: Qt platform plugin "xcb" could not be initialized)*