### PR TITLE
Fix preview dialog setup

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,6 @@
+- Investigate failing tests unrelated to preview dialog update:
+  - `tests/core/filter/test_filter_reset_advanced.py::test_filter_reset_after_complex_filter` expects `translation_status="all"` but receives a set of statuses.
+  - `tests/gui/keyword_filter/test_keyword_filter.py::TestKeywordFilter::test_filter_text_and_keyword_together` fails for the same reason.
+  - `tests/integration/test_viewer_po_file.py::test_save_po_file` fails due to `'EntryModel' object has no attribute 'msgid_plural'` when saving.
+  - `tests/models/test_models.py::test_entry_model` fails because `EntryModel.from_po_entry` returns `None`.
+- These tests appear unrelated to the preview dialog changes and require deeper investigation.

--- a/src/sgpo_editor/gui/main_window.py
+++ b/src/sgpo_editor/gui/main_window.py
@@ -367,7 +367,10 @@ class MainWindow(QMainWindow):
 
         # プレビューダイアログを表示
         dialog = PreviewDialog(self)
-        
+
+        # プレビューダイアログに現在のエントリを設定
+        dialog.set_entry(current_entry)
+
         # 更新シグナルを設定
         dialog.set_update_signal(self.entry_list_facade.entry_selected)
         

--- a/tests/gui/widgets/test_preview_widget.py
+++ b/tests/gui/widgets/test_preview_widget.py
@@ -216,7 +216,10 @@ class TestPreviewIntegration:
 
         # 検証
         mock_preview_dialog.assert_called_once()
-        mock_preview_dialog_instance.set_entry.assert_called_once_with(mock_entry)
+        assert (
+            mock_preview_dialog_instance.set_entry.call_count == 2
+        )
+        mock_preview_dialog_instance.set_entry.assert_called_with(mock_entry)
         mock_preview_dialog_instance.show.assert_called_once()
         mock_preview_dialog_instance.raise_.assert_called_once()
         mock_preview_dialog_instance.activateWindow.assert_called_once()


### PR DESCRIPTION
## Summary
- set entry on preview dialog during show
- ensure integration test accounts for initial preview dialog state
- document unrelated failing tests

## Testing
- `uv run ruff check --fix`
- `uv run ty check src --exit-zero`
- `uv run pytest -q` *(fails: tests/core/filter/test_filter_reset_after_complex_filter, tests/gui/keyword_filter/test_filter_text_and_keyword_together, tests/integration/test_viewer_po_file.py::test_save_po_file, tests/models/test_models.py::test_entry_model)*