### PR TITLE
Implement cache logging and entry model improvements

### DIFF
--- a/_doc/updated_filtering_logic.md
+++ b/_doc/updated_filtering_logic.md
@@ -1,0 +1,8 @@
+# Updated Filtering Logic
+
+This document outlines the latest filtering and caching strategy used in `ViewerPOFileFilter` and `EntryCacheManager`.
+
+* Filter keywords provided to `get_filtered_entries` are merged with the current `search_text`.
+* A unique filter key generated via MD5 is used to store filtered IDs in `EntryCacheManager`.
+* When filter conditions change, `EntryCacheManager.invalidate_filter_cache` is called with the generated key.
+* The cache manager maintains LRU caches for entries and filtered ID lists with size limits defined in configuration.

--- a/src/sgpo_editor/core/cache_manager.py
+++ b/src/sgpo_editor/core/cache_manager.py
@@ -334,10 +334,11 @@ class EntryCacheManager:
             filter_key: 無効化するフィルタキー。指定しない場合はすべて削除する。
         """
         if filter_key is not None:
+            logger.debug(f"invalidate_filter_cache: delete key={filter_key}")
             self._filter_cache.delete(filter_key)
         else:
+            logger.debug("invalidate_filter_cache: clear all filter cache")
             self._filter_cache.clear()
-        logger.debug(f"Filter cache invalidated for key: {filter_key}")
 
     def invalidate_entry(self, key: str) -> None:
         """特定のエントリのキャッシュを無効化する
@@ -786,13 +787,23 @@ class EntryCacheManager:
 
         ToDo Phase 1: フィルタ条件に合致するエントリIDのキャッシュを取得する
         """
-        return self._filter_cache.get(filter_key)
+        ids = self._filter_cache.get(filter_key)
+        if ids is not None:
+            logger.debug(
+                f"get_filtered_ids: hit for key={filter_key} ({len(ids)} ids)"
+            )
+        else:
+            logger.debug(f"get_filtered_ids: miss for key={filter_key}")
+        return ids
 
     def cache_filtered_ids(self, filter_key: str, entry_ids: List[str]) -> None:
         """フィルタ条件に合致するエントリIDをキャッシュする
 
         ToDo Phase 1: フィルタ条件に合致するエントリIDをキャッシュする
         """
+        logger.debug(
+            f"cache_filtered_ids: store {len(entry_ids)} ids for key={filter_key}"
+        )
         self._filter_cache.set(filter_key, entry_ids)
 
     def evaluate_cache_efficiency(self) -> CacheEfficiency:

--- a/src/sgpo_editor/core/viewer_po_file_filter.py
+++ b/src/sgpo_editor/core/viewer_po_file_filter.py
@@ -113,8 +113,20 @@ class ViewerPOFileFilter(ViewerPOFileEntryRetriever):
             str: マージされたフィルターキーワード
         """
         if new_keyword:
-            return new_keyword if not current_search_text else f'{current_search_text} {new_keyword}'  # シンプルなマージ、必要に応じて調整
-        return current_search_text or ''
+            merged = (
+                new_keyword
+                if not current_search_text
+                else f"{current_search_text} {new_keyword}"
+            )
+        else:
+            merged = current_search_text or ""
+        logger.debug(
+            "_merge_filters: new=%s current=%s merged=%s",
+            new_keyword,
+            current_search_text,
+            merged,
+        )
+        return merged
 
     def _generate_filter_key(self, filter_keyword: str) -> str:
         """フィルターキーを生成する
@@ -161,6 +173,9 @@ class ViewerPOFileFilter(ViewerPOFileEntryRetriever):
                 # キャッシュを無効化
                 cache_manager = cm.EntryCacheManager()  # インスタンス取得、必要に応じてシングルトンを考慮
                 filter_key = self._generate_filter_key(self.search_text)  # フィルターキーを生成
+                logger.debug(
+                    "get_filtered_entries: invalidate cache key=%s", filter_key
+                )
                 cache_manager.invalidate_filter_cache(filter_key)
                 self._force_filter_update = True
         else:
@@ -169,6 +184,9 @@ class ViewerPOFileFilter(ViewerPOFileEntryRetriever):
                 self.search_text = self._merge_filters(filter_keyword, self.search_text)
                 cache_manager = cm.EntryCacheManager()
                 filter_key = self._generate_filter_key(self.search_text)
+                logger.debug(
+                    "get_filtered_entries: invalidate cache key=%s", filter_key
+                )
                 cache_manager.invalidate_filter_cache(filter_key)
                 self._force_filter_update = True
 

--- a/src/sgpo_editor/models/entry.py
+++ b/src/sgpo_editor/models/entry.py
@@ -411,6 +411,21 @@ class EntryModel(BaseModel):
         """flagsを小文字に正規化"""
         return [flag.lower() for flag in v]
 
+    @field_validator("occurrences", mode="before")
+    @classmethod
+    def parse_occurrences(cls, v: Any) -> List[tuple[str, int]]:
+        """occurrencesを `(file, line)` タプルのリストに変換する"""
+        if not v:
+            return []
+        parsed: List[tuple[str, int]] = []
+        for item in v:
+            try:
+                file, lineno = item
+                parsed.append((str(file), int(lineno)))
+            except Exception:
+                continue
+        return parsed
+
     def to_dict(self) -> Dict[str, Any]:
         """辞書化"""
         result = {

--- a/tests/core/test_cache_manager.py
+++ b/tests/core/test_cache_manager.py
@@ -147,3 +147,12 @@ def test_config_applied(monkeypatch):
     # max_size=1なのでk1は消える
     assert cm.get_entry("k1") is None
     assert cm.get_entry("k2") is not None
+
+
+def test_filtered_id_cache(cache_manager):
+    key = "abc"
+    ids = ["e1", "e2"]
+    cache_manager.cache_filtered_ids(key, ids)
+    assert cache_manager.get_filtered_ids(key) == ids
+    cache_manager.invalidate_filter_cache(key)
+    assert cache_manager.get_filtered_ids(key) is None

--- a/tests/models/entry/test_entry_model.py
+++ b/tests/models/entry/test_entry_model.py
@@ -487,6 +487,15 @@ class TestEntryModel(unittest.TestCase):
         entry2 = EntryModel.from_dict(data)
         self.assertEqual(entry2.metadata, metadata)
 
+    def test_occurrences_validator(self):
+        data = {
+            "msgid": "a",
+            "msgstr": "b",
+            "occurrences": [("file.py", "12"), ("other", 5)],
+        }
+        entry = EntryModel(**data)
+        assert entry.occurrences == [("file.py", 12), ("other", 5)]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve filter cache management with debug logging
- log merged filter keywords
- normalize occurrences field in EntryModel
- test filter id caching and occurrences parsing
- document new filtering and caching logic

## Testing
- `uv run ruff check --fix`
- `uv run ty check src --exit-zero`
- `uv run pytest -q` *(fails: Qt platform plugin xcb could not be loaded)*